### PR TITLE
Treat `-abc` as unmatched if `-a` is not matched

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -510,6 +510,22 @@ impl Options {
                     }
                 } else {
                     was_long = false;
+                    // rustc, for example, accepts a number of flags that don't
+                    // follow the usual convention of `-abc` being equivalent to
+                    // `-a`, `-b`, `-c`. For example, `-L<some-path>` passed to
+                    // rustc by cargo. The entire flag need to be treated as
+                    // unmatched rather than split, which would lead to
+                    // individual characters in `<some-path>` being parsed as
+                    // flags. This is needed to use `parse_partial` with rustc
+                    // invocations
+                    let first_matches = self
+                        .grps
+                        .iter()
+                        .any(|opt_group: &OptGroup| opt_group.short_name == cur[1..2]);
+                    if !first_matches {
+                        unmatched.push(osstr);
+                        continue;
+                    }
                     for (j, ch) in cur.char_indices().skip(1) {
                         let opt = Short(ch);
 

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1333,3 +1333,18 @@ fn test_opt_strs_pos() {
         ]
     );
 }
+
+#[test]
+fn test_unmatched_short_opts() {
+    let args: Vec<&str> = vec!["-Lhh"];
+    let mut opts = Options::new();
+    opts.optflag("h", "help", "print this help menu");
+    // This should not report an error about `help` being passed twice.
+    match opts.parse_partial(&args) {
+        Ok((_, unmatched)) => {
+            assert_eq!(unmatched.len(), 1);
+            assert_eq!(*unmatched[0], "-Lhh");
+        }
+        Err(e) => panic!("{}", e),
+    }
+}


### PR DESCRIPTION
This allows using parse_partial with flags that don't follow the convention of `-abc` being a shorthand for `-a -b -c`, such as linker-related flags accepted by rustc.